### PR TITLE
Run unit tests against lowest matching dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,3 +172,41 @@ jobs:
         with:
           name: 'PHP ${{ matrix.php }} with ${{ fromJson(matrix.db).vendor }}'
           path: 'clover.xml'
+
+  unit-lowest:
+    name: 'Run unit tests with lowest-matching dependencies versions'
+    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
+    runs-on: 'ubuntu-20.04'
+
+    env:
+      db_dsn: 'sqlite://tmp/test.sql'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.4'
+          tools: 'composer'
+          extensions: 'mbstring, intl, pdo_sqlite'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: "composer-lowest-${{ hashFiles('**/composer.json') }}"
+          restore-keys: |
+            composer-lowest-
+            composer-
+
+      - name: 'Update dependencies with Composer'
+        run: 'composer update --prefer-lowest --prefer-dist --no-interaction'
+
+      - name: 'Run PHPUnit'
+        run: 'vendor/bin/phpunit'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Placeholders plugin for BEdita
 
+[![GitHub Actions tests](https://github.com/bedita/placeholders/actions/workflows/test.yml/badge.svg?event=push&branch=main)](https://github.com/bedita/placeholders/actions/workflows/test.yml?query=event%3Apush+branch%3Amain)
+[![codecov](https://codecov.io/gh/bedita/placeholders/branch/main/graph/badge.svg)](https://codecov.io/gh/bedita/placeholders)
+
 ## Installation
 
 You can install this plugin into your CakePHP application using [composer](https://getcomposer.org).

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "cakephp/plugin-installer": "^1.3",
-        "phpunit/phpunit": "^5.7.14|^6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
     "require": {
         "php": ">= 7.4",
         "cakephp/cakephp": "^3.8",
-        "bedita/core": "dev-4-cactus as 4.4.0-dev",
-        "bedita/api": "dev-4-cactus as 4.4.0-dev"
+        "bedita/core": "dev-4-cactus as 4.7.0-dev",
+        "bedita/api": "dev-4-cactus as 4.7.0-dev"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
-        "cakephp/plugin-installer": "^1.0",
+        "cakephp/plugin-installer": "^1.3",
         "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {

--- a/tests/TestCase/Controller/Component/PlaceholdersComponentTest.php
+++ b/tests/TestCase/Controller/Component/PlaceholdersComponentTest.php
@@ -123,7 +123,9 @@ class PlaceholdersComponentTest extends TestCase
     public function testBeforeFilter(?Exception $expected, ServerRequest $request): void
     {
         if ($expected !== null) {
-            $this->expectExceptionObject($expected);
+            $this->expectException(get_class($expected));
+            $this->expectExceptionCode($expected->getCode());
+            $this->expectExceptionMessage($expected->getMessage());
         }
 
         $this->controller->setRequest($request);


### PR DESCRIPTION
This MR adds a CI job to run unit tests against lowest matching Composer dependencies. This helps us ensure that the requirements documented in the `composer.json` are actually at the minimum suitable version for this package. If that test fails while other pass, we probably need to bump some dependency version.

Additionally, status badges have been added to the README.