### PR TITLE
Update code quality tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,10 +13,6 @@ trim_trailing_whitespace = true
 [*.bat]
 end_of_line = crlf
 
-[*.yml]
-indent_style = space
-indent_size = 2
-
-[Vagrantfile]
+[*.{yml,yaml,neon}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,7 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP CodeSniffer'
-        run: |
-          vendor/bin/phpcs -n -p --extensions=php \
-            --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=/Migrations/,/Seeds/ \
-            ./src ./tests
+        run: 'vendor/bin/phpcs -n'
 
   stan:
     name: 'Static code analyzer'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,8 +132,7 @@ jobs:
           php-version: '${{ matrix.php }}'
           tools: 'composer'
           extensions: 'mbstring, intl, pdo_${{ fromJson(matrix.db).pdo }}'
-          coverage: 'pcov'
-          ini-values: 'pcov.directory=., pcov.exclude="~vendor~"'
+          coverage: 'none' # Using `phpdbg`
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
@@ -151,11 +150,8 @@ jobs:
       - name: 'Install dependencies with Composer'
         run: 'composer install --prefer-dist --no-interaction'
 
-      - name: 'Setup PCOV clobber'
-        run: 'composer require pcov/clobber && vendor/bin/pcov clobber'
-
       - name: 'Run PHPUnit with coverage'
-        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+        run: 'phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml'
 
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '7.4'
-          tools: 'composer, phpstan'
+          tools: 'composer'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -81,8 +81,7 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP STAN'
-        run: |
-          phpstan analyse --no-progress src
+        run: 'vendor/bin/phpstan analyse --no-progress --error-format=github'
 
   unit:
     name: 'Run unit tests'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,9 @@ jobs:
       - name: 'Install dependencies with Composer'
         run: 'composer install --prefer-dist --no-interaction'
 
+      - name: 'Dump Composer autoloader'
+        run: 'composer dump-autoload --classmap-authoritative --no-cache'
+
       - name: 'Run PHPUnit with coverage'
         run: 'phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml'
 
@@ -199,6 +202,9 @@ jobs:
 
       - name: 'Update dependencies with Composer'
         run: 'composer update --prefer-lowest --prefer-dist --no-interaction'
+
+      - name: 'Dump Composer autoloader'
+        run: 'composer dump-autoload --classmap-authoritative --no-cache'
 
       - name: 'Run PHPUnit'
         run: 'vendor/bin/phpunit'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /composer.lock
+/phpcs.xml
 /phpunit.xml
 /vendor
 config/Migrations/schema-dump-default.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /composer.lock
 /phpcs.xml
+/phpstan.neon
 /phpunit.xml
 /vendor
 config/Migrations/schema-dump-default.lock

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "cakephp/plugin-installer": "^1.3",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "phpstan/phpstan": "^1.5"
     },
     "autoload": {
         "psr-4": {
@@ -29,6 +30,7 @@
     "scripts": {
         "cs-check": "vendor/bin/phpcs",
         "cs-fix": "vendor/bin/phpcbf",
+        "stan": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/phpunit --colors=always"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,8 @@
         }
     },
     "scripts": {
-        "cs-setup": [
-            "vendor/bin/phpcs --config-set installed_paths vendor/cakephp/cakephp-codesniffer",
-            "vendor/bin/phpcs --config-set default_standard CakePHP",
-            "vendor/bin/phpcs --config-set colors 1"
-        ],
-        "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
+        "cs-check": "vendor/bin/phpcs",
+        "cs-fix": "vendor/bin/phpcbf",
         "test": "vendor/bin/phpunit --colors=always"
     },
     "config": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="App">
+    <file>./src</file>
+    <file>./tests</file>
+
+    <arg name="colors"/>
+    <arg value="p"/>
+
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
+
+    <rule ref="CakePHP"/>
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  level: 8
+  checkMissingIterableValueType: false

--- a/src/Model/Behavior/PlaceholdedBehavior.php
+++ b/src/Model/Behavior/PlaceholdedBehavior.php
@@ -73,7 +73,7 @@ class PlaceholdedBehavior extends Behavior
 
             $refCount = $Table->find()
                 ->select(['existing' => 1])
-                ->where(array_combine(
+                ->where((array)array_combine(
                     array_map([$Table, 'aliasField'], (array)$Table->getPrimaryKey()),
                     $entity->extract((array)$Table->getPrimaryKey())
                 ))

--- a/src/Model/Behavior/PlaceholdersBehavior.php
+++ b/src/Model/Behavior/PlaceholdersBehavior.php
@@ -142,6 +142,7 @@ class PlaceholdersBehavior extends Behavior
      */
     protected function prepareEntities(Table $table, array $placeholders): array
     {
+        /** @var string $pk */
         $pk = $table->getPrimaryKey();
         $ids = array_column($placeholders, 'id');
         if (empty($ids)) {
@@ -150,7 +151,9 @@ class PlaceholdersBehavior extends Behavior
 
         $fields = [$table->aliasField($pk)];
         if ($table->hasAssociation('ObjectTypes')) {
-            $fields = array_merge($fields, [$table->aliasField($table->getAssociation('ObjectTypes')->getForeignKey())]);
+            /** @var string $fk */
+            $fk = $table->getAssociation('ObjectTypes')->getForeignKey();
+            $fields = array_merge($fields, [$table->aliasField($fk)]);
         }
 
         return $table->find()

--- a/tests/TestCase/Controller/Component/PlaceholdersComponentTest.php
+++ b/tests/TestCase/Controller/Component/PlaceholdersComponentTest.php
@@ -114,7 +114,7 @@ class PlaceholdersComponentTest extends TestCase
      * Test {@see PlaceholdersComponent::beforeFilter()}.
      *
      * @param \Exception|null $expected Expected exception.
-     * @param \Cake\Http\ServerRequest Request.
+     * @param \Cake\Http\ServerRequest $request Request.
      * @return void
      *
      * @covers ::beforeFilter()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,7 @@ define('LOGS', ROOT . DS . 'logs' . DS);
 define('CONFIG', ROOT . DS . 'config' . DS);
 define('CACHE', TMP . 'cache' . DS);
 define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+define('UNIT_TEST_RUN', 1); // TODO: remove after https://github.com/bedita/bedita/pull/1890 is merged
 
 Configure::write('debug', true);
 Configure::write('App', [


### PR DESCRIPTION
This PR:

- [x] adds configuration for PHPCS to avoid setting options via CLI arguments every time
- [x] adds `phpstan/phpstan` to dev dependencies and uses the installed version in CI
- [x] uses `phpdbg` for coverage, rather than relying on clobbed PCov
- [x] dumps Composer autoloader and authoritative classmap before running unit tests in an attempt to catch usages of deprecated aliased classes which may break in production